### PR TITLE
fix: missing authorization_providers_ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/zapp-pipes-provider-sportsmaxds",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/zapp-pipes-provider-sportsmaxds",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "this plugin enable to load content from applicaster2 and support multiple broadcasters.",
   "main": "lib/index.js",
   "scripts": {

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -4,11 +4,11 @@
     "https://github.com/applicaster-plugins/zapp-pipes-provider-sportsmax"
   ],
   "dependency_name": "@applicaster/zapp-pipes-provider-sportsmaxds",
-  "dependency_version": "1.2.2",
+  "dependency_version": "1.2.3",
   "platform": null,
   "author_name": "Yarovoy Vladislav",
   "author_email": "yarovoy@scand.com",
-  "manifest_version": "1.2.2",
+  "manifest_version": "1.2.3",
   "name": "Sportsmax ds",
   "description": "",
   "type": "data_source_provider",

--- a/src/provider/handler/commands/getChannelList.js
+++ b/src/provider/handler/commands/getChannelList.js
@@ -69,7 +69,8 @@ export function getChannelList(params, nativeBridge) {
 			"extensions": {
 				free,
 				"channel_id": channel["ui_tag"],
-				"ds_product_ids": authProviders
+				"ds_product_ids": authProviders,
+				"authorization_providers_ids": authProviders
 			}
 		}
 	}


### PR DESCRIPTION
## Description: Fix
### Ticket: https://applicaster.atlassian.net/browse/IM-852

Customizable parameters in the **Digicel Login Plugin** is missing. As DSP doesn't provide `authorization_providers_ids` extension field in the `channel-list` endpoint